### PR TITLE
Bugfix :: Fix various compilation warnings

### DIFF
--- a/modules/realm_core/include/realm_core/settings_base.h
+++ b/modules/realm_core/include/realm_core/settings_base.h
@@ -89,6 +89,7 @@ class SettingsBase
         if (m_type == VariantType::INT) return m_int_container.value;
         if (m_type == VariantType::DOUBLE) return static_cast<int>(m_double_container.value);
         if (m_type == VariantType::STRING) throw(std::bad_cast());
+        throw(std::bad_cast());
       }
 
       float toFloat() const
@@ -96,6 +97,7 @@ class SettingsBase
         if (m_type == VariantType::INT) return static_cast<float>(m_int_container.value);
         if (m_type == VariantType::DOUBLE) return static_cast<float>(m_double_container.value);
         if (m_type == VariantType::STRING) throw(std::bad_cast());
+        throw(std::bad_cast());
       }
 
       double toDouble() const
@@ -103,6 +105,7 @@ class SettingsBase
         if (m_type == VariantType::INT) return static_cast<double>(m_int_container.value);
         if (m_type == VariantType::DOUBLE) return m_double_container.value;
         if (m_type == VariantType::STRING) throw(std::bad_cast());
+        throw(std::bad_cast());
       }
 
       std::string toString() const
@@ -110,6 +113,7 @@ class SettingsBase
         if (m_type == VariantType::INT) return std::to_string(m_int_container.value);
         if (m_type == VariantType::DOUBLE) return std::to_string(m_double_container.value);
         if (m_type == VariantType::STRING) return m_string_container.value;
+        return m_string_container.value;
       }
 
       std::string help() const
@@ -117,6 +121,7 @@ class SettingsBase
         if (m_type == VariantType::INT) return m_int_container.help;
         if (m_type == VariantType::DOUBLE) return m_double_container.help;
         if (m_type == VariantType::STRING) return m_string_container.help;
+        return m_string_container.help;
       }
 
     private:

--- a/modules/realm_core/src/cv_grid_map.cpp
+++ b/modules/realm_core/src/cv_grid_map.cpp
@@ -221,6 +221,7 @@ CvGridMap::Layer CvGridMap::getLayer(const std::string& layer_name) const
   for (const auto& layer : m_layers)
     if (layer.name == layer_name)
       return layer;
+  throw std::out_of_range("No layer with name '" + layer_name + "' available.");
 }
 
 std::vector<std::string> CvGridMap::getAllLayerNames() const

--- a/modules/realm_io/include/realm_io/gdal_continuous_writer.h
+++ b/modules/realm_io/include/realm_io/gdal_continuous_writer.h
@@ -38,7 +38,7 @@ public:
 public:
   GDALContinuousWriter(const std::string &thread_name, int64_t sleep_time, bool verbose);
 
-  bool requestSaveGeoTIFF(const CvGridMap::Ptr &map,
+  void requestSaveGeoTIFF(const CvGridMap::Ptr &map,
                           const uint8_t &zone,
                           const std::string &filename,
                           bool do_build_overview = false,

--- a/modules/realm_io/src/gdal_continuous_writer.cpp
+++ b/modules/realm_io/src/gdal_continuous_writer.cpp
@@ -28,7 +28,7 @@ io::GDALContinuousWriter::GDALContinuousWriter(const std::string &thread_name, i
 {
 }
 
-bool io::GDALContinuousWriter::requestSaveGeoTIFF(const CvGridMap::Ptr &map,
+void io::GDALContinuousWriter::requestSaveGeoTIFF(const CvGridMap::Ptr &map,
                                                   const uint8_t &zone,
                                                   const std::string &filename,
                                                   bool do_build_overview,

--- a/modules/realm_io/src/realm_import.cpp
+++ b/modules/realm_io/src/realm_import.cpp
@@ -44,6 +44,11 @@ camera::Pinhole io::loadCameraFromYaml(const std::string &filepath, double* fps)
                          (*settings)["p1"].toDouble(), (*settings)["p2"].toDouble(), (*settings)["k3"].toDouble());
     return cam;
   }
+  else
+  {
+      throw std::runtime_error("Unable to load camera settings from yaml file at: " + filepath);
+  }
+
 }
 
 cv::Mat io::loadGeoreferenceFromYaml(const std::string &filepath)

--- a/modules/realm_ortho/src/tile_cache.cpp
+++ b/modules/realm_ortho/src/tile_cache.cpp
@@ -384,6 +384,7 @@ size_t TileCache::estimateByteSize(const Tile::Ptr &tile) const
   tile->unlock();
 
   //return bytes;
+  return 0;
 }
 
 void TileCache::updatePrediction(int zoom_level, const cv::Rect2i &roi_current)

--- a/modules/realm_stages/src/densification.cpp
+++ b/modules/realm_stages/src/densification.cpp
@@ -201,7 +201,7 @@ Frame::Ptr Densification::consistencyFilter(std::deque<std::pair<Frame::Ptr, cv:
 
   if (perc_coverage < 30.0)
   {
-    LOG_IF_F(WARNING, m_verbose, "Depthmap coverage too low (%3.1f%%). Assuming plane surface.");
+    LOG_IF_F(WARNING, m_verbose, "Depthmap coverage too low (%3.1f%%). Assuming plane surface.", perc_coverage);
     frame->setDepthmap(nullptr);
 
     for (auto it = buffer_denoise->begin(); it != buffer_denoise->end(); ) {

--- a/modules/realm_stages/src/mosaicing.cpp
+++ b/modules/realm_stages/src/mosaicing.cpp
@@ -394,6 +394,8 @@ std::vector<Face> Mosaicing::createMeshFaces(const CvGridMap::Ptr &map)
   //std::vector<cv::Point2i> vertex_ids = _mesher->buildMesh(*mesh_sampled, "valid");
   //std::vector<Face> faces = cvtToMesh((*mesh_sampled), "elevation", "color_rgb", vertex_ids);
   //return faces;
+  // Placeholder return, there are a few calls that try to use this
+  return std::vector<Face>();
 }
 
 void Mosaicing::publish(const Frame::Ptr &frame, const CvGridMap::Ptr &map, const CvGridMap::Ptr &update, uint64_t timestamp)

--- a/modules/realm_stages/src/stage_settings_factory.cpp
+++ b/modules/realm_stages/src/stage_settings_factory.cpp
@@ -43,6 +43,7 @@ StageSettings::Ptr StageSettingsFactory::load(const std::string &stage_type_set,
     return loadDefault<MosaicingSettings>(stage_type_set, filepath);
   if (stage_type_set == "tileing")
     return loadDefault<TileingSettings>(stage_type_set, filepath);
+  throw(std::invalid_argument("Error: Could not load stage settings. Did not recognize stage type: " + stage_type_set));
 }
 
 template <typename T>

--- a/modules/realm_vslam/realm_vslam_base/include/realm_vslam_base/visual_slam_IF.h
+++ b/modules/realm_vslam/realm_vslam_base/include/realm_vslam_base/visual_slam_IF.h
@@ -98,14 +98,9 @@ public:
   virtual void queueImuData(const ImuData &)
   {};
 
-  virtual cv::Mat getMapPoints() const
-  {};
+  virtual cv::Mat getTrackedMapPoints() const = 0;
 
-  virtual cv::Mat getTrackedMapPoints() const
-  {};
-
-  virtual bool drawTrackedImage(cv::Mat &img) const
-  {};
+  virtual bool drawTrackedImage(cv::Mat &img) const = 0;
 
   // Callbacks
   virtual void registerUpdateTransport(const PoseUpdateFuncCb &func)


### PR DESCRIPTION
## Description
Update function returns and other minor syntax errors that were causing compiler warnings.


## Reason
Many warnings when building can hide important warnings and errors making it tougher to catch new bugs in the future.


## Method / Design
In many cases, there were missing returns.  Where applicable, and threw exceptions, otherwise I assigned default return statements, or removed the return entirely if it was never used in the code.

## Testing
Compiled and ran on:
Ubuntu 20.04 - Desktop


## Other Notes
None