### PR TITLE
Add namespaces to header only libraries to prevent collisions

### DIFF
--- a/modules/realm_ortho/include/realm_ortho/dsm.h
+++ b/modules/realm_ortho/include/realm_ortho/dsm.h
@@ -35,7 +35,8 @@
 
 namespace realm
 {
-
+namespace ortho
+{
 class DigitalSurfaceModel
 {
   public:
@@ -45,8 +46,8 @@ class DigitalSurfaceModel
     // Wrapping typedefs in realm convention
     static constexpr size_t kMaxLeaf = 10u;
     static constexpr size_t kDimensionKdTree = 2u;
-    using PointCloudAdaptor_t = PointCloudAdaptor<PointCloud<double>>;
-    using KdTree_t = nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Adaptor<double, PointCloudAdaptor_t>, PointCloudAdaptor_t, kDimensionKdTree>;
+    using PointCloudAdaptor_t = PointCloudAdaptor<ortho::PointCloud<double>>;
+    using KdTree_t = nanoflann::KDTreeSingleIndexAdaptor<ortho::nanoflann::L2_Adaptor<double, PointCloudAdaptor_t>, PointCloudAdaptor_t, kDimensionKdTree>;
   public:
     enum class SurfaceNormalMode
     {
@@ -93,7 +94,7 @@ class DigitalSurfaceModel
     CvGridMap::Ptr m_surface;
 
     //! Input point cloud (only for elevation surface)
-    PointCloud<double> m_point_cloud;
+    ortho::PointCloud<double> m_point_cloud;
 
     //! Adapter for point cloud k-d tree and NN search (only for elevation surface)
     std::unique_ptr<PointCloudAdaptor_t> m_point_cloud_adaptor;
@@ -179,7 +180,7 @@ class DigitalSurfaceModel
         return indices;
     }
 };
-
+} // namespace ortho
 } // namespace realm
 
 #endif //PROJECT_DSM_H

--- a/modules/realm_ortho/include/realm_ortho/nanoflann.h
+++ b/modules/realm_ortho/include/realm_ortho/nanoflann.h
@@ -66,6 +66,8 @@
 #endif
 #endif
 
+namespace realm {
+namespace ortho {
 namespace nanoflann {
 /** @addtogroup nanoflann_grp nanoflann C++ library for ANN
   *  @{ */
@@ -1454,5 +1456,6 @@ struct KDTreeEigenMatrixAdaptor {
 
 /** @} */  // end of grouping
 }  // end of NS
-
+} // end of NS
+} // end of NS
 #endif /* NANOFLANN_H_ */

--- a/modules/realm_ortho/include/realm_ortho/nearest_neighbor.h
+++ b/modules/realm_ortho/include/realm_ortho/nearest_neighbor.h
@@ -15,6 +15,8 @@
 #include <eigen3/Eigen/Core>
 #include <realm_ortho/nanoflann.h>
 
+namespace realm {
+namespace ortho {
 template <template <typename, typename> class Container, typename Type>
 struct AlignedType {
   typedef Container<Type, Eigen::aligned_allocator<Type> > type;
@@ -74,5 +76,6 @@ struct PointCloudAdaptor {
     return false;
   }
 };  // end of PointCloudAdaptor
-
+}
+}
 #endif  // NEAREST_NEIGHBOR_H_

--- a/modules/realm_ortho/src/dsm.cpp
+++ b/modules/realm_ortho/src/dsm.cpp
@@ -22,7 +22,7 @@
 
 #include <opencv2/imgproc.hpp>
 
-using namespace realm;
+using namespace realm::ortho;
 
 DigitalSurfaceModel::DigitalSurfaceModel(const cv::Rect2d &roi, double elevation)
 : m_use_prior_normals(false),
@@ -248,7 +248,7 @@ void DigitalSurfaceModel::computeElevation(const cv::Mat &point_cloud)
     m_surface->add("elevation_normal", elevation_normal);
 }
 
-CvGridMap::Ptr DigitalSurfaceModel::getSurfaceGrid()
+realm::CvGridMap::Ptr DigitalSurfaceModel::getSurfaceGrid()
 {
   return m_surface;
 }

--- a/modules/realm_stages/include/realm_stages/surface_generation.h
+++ b/modules/realm_stages/include/realm_stages/surface_generation.h
@@ -60,7 +60,7 @@ class SurfaceGeneration : public StageBase
     bool m_is_projection_plane_offset_computed;
     double m_projection_plane_offset;
 
-    DigitalSurfaceModel::SurfaceNormalMode m_mode_surface_normals;
+    ortho::DigitalSurfaceModel::SurfaceNormalMode m_mode_surface_normals;
 
     SaveSettings m_settings_save;
 
@@ -86,8 +86,8 @@ class SurfaceGeneration : public StageBase
     double computeProjectionPlaneOffset(const Frame::Ptr &frame);
 
     SurfaceAssumption computeSurfaceAssumption(const Frame::Ptr &frame);
-    DigitalSurfaceModel::Ptr createPlanarSurface(const Frame::Ptr &frame);
-    DigitalSurfaceModel::Ptr createElevationSurface(const Frame::Ptr &frame);
+    ortho::DigitalSurfaceModel::Ptr createPlanarSurface(const Frame::Ptr &frame);
+    ortho::DigitalSurfaceModel::Ptr createElevationSurface(const Frame::Ptr &frame);
 };
 
 } // namespace stages

--- a/modules/realm_stages/src/surface_generation.cpp
+++ b/modules/realm_stages/src/surface_generation.cpp
@@ -24,6 +24,7 @@
 
 using namespace realm;
 using namespace stages;
+using namespace realm::ortho;
 
 SurfaceGeneration::SurfaceGeneration(const StageSettings::Ptr &settings, double rate)
 : StageBase("surface_generation", (*settings)["path_output"].toString(), rate, (*settings)["queue_size"].toInt()),


### PR DESCRIPTION
## Description
Add realm::ortho namespace to some header libraries to avoid collisions.

## Reason
When building the library into other code bases, some naming conflicts were discovered.  Since this codebase maintains a local copy of some header only libraries, they were modified to add a namespace to prevent collisions.

## Method / Design
All collisions were in the ortho module.  A few headers were modified and moved to the realm, or realm::ortho namespace.


## Testing
Compiled and ran on:
Ubuntu 20.04 - Desktop


## Other Notes
None