### PR TITLE
Improve System Shutdown Speed

### DIFF
--- a/modules/realm_core/include/realm_core/timer.h
+++ b/modules/realm_core/include/realm_core/timer.h
@@ -7,6 +7,8 @@
 #include <chrono>
 #include <functional>
 #include <atomic>
+#include <mutex>
+#include <condition_variable>
 
 namespace realm {
 
@@ -20,6 +22,18 @@ namespace realm {
         explicit Timer(const std::chrono::milliseconds &period, const std::function<void()> &func);
         ~Timer();
 
+
+        /**
+         * Waitfor that allows the timer to be interrupted for quicker shutdowns
+         * @param duration The sleep time between updates
+         * @return True if we need to abort
+         */
+        template<class Duration>
+        bool interruptable_wait_for(Duration duration) {
+            std::unique_lock<std::mutex> l(m_stop_mtx);
+            return !m_cond.wait_for(l, duration, [this]() { return !m_in_flight; });
+        }
+
         static long getCurrentTimeSeconds();
         static long getCurrentTimeMilliseconds();
         static long getCurrentTimeMicroseconds();
@@ -30,6 +44,9 @@ namespace realm {
         std::function<void()> m_func;
         std::atomic<bool> m_in_flight;
         std::thread m_thread;
+
+        std::condition_variable m_cond;
+        std::mutex m_stop_mtx;
     };
 
 } // namespace realm

--- a/modules/realm_stages/include/realm_stages/pose_estimation.h
+++ b/modules/realm_stages/include/realm_stages/pose_estimation.h
@@ -63,6 +63,8 @@ class PoseEstimation : public StageBase
                    const ImuSettings::Ptr &imu_set,
                    double rate);
     ~PoseEstimation();
+
+    void finishCallback() override;
     void addFrame(const Frame::Ptr &frame) override;
     bool process() override;
 

--- a/modules/realm_stages/src/pose_estimation.cpp
+++ b/modules/realm_stages/src/pose_estimation.cpp
@@ -78,6 +78,10 @@ PoseEstimation::PoseEstimation(const StageSettings::Ptr &stage_set,
 
 PoseEstimation::~PoseEstimation()
 {
+}
+
+void PoseEstimation::finishCallback()
+{
   if (m_use_vslam) {
     m_vslam->close();
   }

--- a/modules/realm_vslam/realm_vslam_base/src/open_vslam.cpp
+++ b/modules/realm_vslam/realm_vslam_base/src/open_vslam.cpp
@@ -134,6 +134,7 @@ VisualSlamIF::State OpenVslam::track(Frame::Ptr &frame, const cv::Mat &T_c2w_ini
 
 void OpenVslam::close()
 {
+  m_vslam->request_terminate();
   m_vslam->shutdown();
   m_keyframe_updater->requestFinish();
   m_keyframe_updater->join();


### PR DESCRIPTION
## Description

Some threads were slow to shut down, taking 5-10 seconds after system shutdown to fully exit.  This appeared to be primarily caused by the FPS timers not being interruptable, but there were other minor shutdown tasks that would take a while.

## Reason

A quicker shutdown allows us to release resources quicker on systems, allowing a full restarts of the code in a shorter time frame.

## Method / Design

Changes included:

- Change the OpenRealm::Timer code to use conditional variables in the wait statement allowing the timer to be interrupted
- Moved the shutdown code for pose estimation to the finishCallback to start shutting down vslam earlier in the shutdown phase
- Set the OpenVSlam terminate flag to help exit their loop quicker

## Testing
Compiled and run on:
Ubuntu 20.04 - Desktop

## Other Notes
