### PR TITLE
Address Occasional Segfaults when OpenVSLAM resets

### DIFF
--- a/modules/realm_vslam/realm_vslam_base/include/realm_vslam_base/open_vslam.h
+++ b/modules/realm_vslam/realm_vslam_base/include/realm_vslam_base/open_vslam.h
@@ -47,6 +47,8 @@ private:
   mutable std::mutex m_mutex_last_keyframe;
   openvslam::data::keyframe* m_last_keyframe;
 
+  openvslam::tracker_state_t m_previous_state;
+
   std::shared_ptr<openvslam::system> m_vslam;
   std::shared_ptr<openvslam::config> m_config;
   std::shared_ptr<openvslam::publish::frame_publisher> m_frame_publisher;
@@ -56,6 +58,9 @@ private:
   cv::Mat getLastDrawnFrame() const;
   cv::Mat invertPose(const cv::Mat &pose) const;
   cv::Mat convertToCv(const openvslam::Mat44_t &mat) const;
+
+  void resetOpenVSlam();
+  void resetKeyframeUpdater();
 };
 
 class OpenVslamKeyframeUpdater : public WorkerThreadBase

--- a/modules/realm_vslam/realm_vslam_base/include/realm_vslam_base/open_vslam.h
+++ b/modules/realm_vslam/realm_vslam_base/include/realm_vslam_base/open_vslam.h
@@ -75,6 +75,9 @@ private:
   /// Container for OpenREALM frames to corresponding OpenVSLAM keyframe
   std::list<std::pair<std::weak_ptr<Frame>, openvslam::data::keyframe*>> m_keyframe_links;
 
+  /// Mutex to prevent modifying the keyframes list while inside an iterator
+  mutable std::mutex m_mutex_keyframes;
+
   bool process() override;
 
   void reset() override;

--- a/modules/realm_vslam/realm_vslam_base/src/open_vslam.cpp
+++ b/modules/realm_vslam/realm_vslam_base/src/open_vslam.cpp
@@ -11,6 +11,7 @@ using namespace realm;
 
 OpenVslam::OpenVslam(const VisualSlamSettings::Ptr &vslam_set, const CameraSettings::Ptr &cam_set)
  : m_nrof_keyframes(0),
+   m_previous_state(openvslam::tracker_state_t::NotInitialized),
    m_last_keyframe(nullptr),
    m_resizing((*vslam_set)["resizing"].toDouble()),
    m_path_vocabulary((*vslam_set)["path_vocabulary"].toString()),
@@ -75,7 +76,7 @@ VisualSlamIF::State OpenVslam::track(Frame::Ptr &frame, const cv::Mat &T_c2w_ini
   m_last_drawn_frame = m_frame_publisher->draw_frame();
   m_mutex_last_drawn_frame.unlock();
 
-  // In case tracking was successfull and slam not lost
+  // In case tracking was successful and slam not lost
   if (tracker_state == openvslam::tracker_state_t::Tracking)
   {
     // Get list of keyframes
@@ -106,6 +107,8 @@ VisualSlamIF::State OpenVslam::track(Frame::Ptr &frame, const cv::Mat &T_c2w_ini
     cv::Mat surface_pts = getTrackedMapPoints();
     frame->setSparseCloud(surface_pts, true);
 
+    m_previous_state = tracker_state;
+
     // Check current state of the slam
     if (m_nrof_keyframes == 0 && current_nrof_keyframes > 0)
     {
@@ -128,6 +131,14 @@ VisualSlamIF::State OpenVslam::track(Frame::Ptr &frame, const cv::Mat &T_c2w_ini
       return State::FRAME_INSERT;
     }
   }
+  else if ((m_previous_state == openvslam::tracker_state_t::Tracking || m_previous_state == openvslam::tracker_state_t::Lost) &&
+            (tracker_state == openvslam::tracker_state_t::NotInitialized || tracker_state == openvslam::tracker_state_t::Initializing)) {
+    // If we had tracking, then lost it then OpenVSlam initiated a reset and we should reset our local frames as well
+    LOG_F(INFO, "Internal OpenVSLAM reset detected, resetting keyframe updater (State: %d was %d)", tracker_state, m_previous_state);
+    resetKeyframeUpdater();
+  }
+
+  m_previous_state = tracker_state;
 
   return State::LOST;
 }
@@ -141,14 +152,22 @@ void OpenVslam::close()
 
 void OpenVslam::reset()
 {
-  LOG_F(INFO, "Reseting visual SLAM...");
-  m_vslam->request_reset();
-  m_keyframe_updater->requestReset();
+  resetOpenVSlam();
+  resetKeyframeUpdater();
+  LOG_F(INFO, "Finished reseting visual SLAM.");
+}
 
+void OpenVslam::resetOpenVSlam() {
+  LOG_F(INFO, "Resetting visual SLAM...");
+  m_vslam->request_reset();
+}
+
+void OpenVslam::resetKeyframeUpdater() {
+  LOG_F(INFO, "Resetting keyframe updater...");
+  m_keyframe_updater->requestReset();
   std::lock_guard<std::mutex> lock(m_mutex_last_keyframe);
   m_last_keyframe = nullptr;
   m_nrof_keyframes = 0;
-  LOG_F(INFO, "Finished reseting visual SLAM.");
 }
 
 cv::Mat OpenVslam::getTrackedMapPoints() const

--- a/modules/realm_vslam/realm_vslam_base/src/open_vslam.cpp
+++ b/modules/realm_vslam/realm_vslam_base/src/open_vslam.cpp
@@ -254,7 +254,7 @@ bool OpenVslamKeyframeUpdater::process()
 
   bool has_processed = false;
 
-  for (auto it = m_keyframe_links.begin(); it != m_keyframe_links.end(); )
+  for (auto it = m_keyframe_links.begin(); it != m_keyframe_links.end(); it++)
   {
     std::shared_ptr<Frame> frame_realm = it->first.lock();
     openvslam::data::keyframe* frame_slam = it->second;

--- a/modules/realm_vslam/realm_vslam_base/src/open_vslam.cpp
+++ b/modules/realm_vslam/realm_vslam_base/src/open_vslam.cpp
@@ -243,11 +243,15 @@ void OpenVslamKeyframeUpdater::add(const std::weak_ptr<Frame> &frame_realm, open
 {
   // We create a connection between the OpenREALM frames and the OpenVSLAM keyframes, so we can update points and
   // poses easily
+  std::lock_guard<std::mutex> lock(m_mutex_keyframes);
   m_keyframe_links.emplace_back(std::make_pair(frame_realm, frame_vslam));
 }
 
 bool OpenVslamKeyframeUpdater::process()
 {
+  // We need to lock down the addition of keyframes while inside the iterator
+  std::lock_guard<std::mutex> lock(m_mutex_keyframes);
+
   bool has_processed = false;
 
   for (auto it = m_keyframe_links.begin(); it != m_keyframe_links.end(); )


### PR DESCRIPTION
## Description

A hard crash would occationally occur if the VSLAM system performed an internal reset due to a number of conditions.  This attempts to address that crash with a couple of thread safety updates.

More details in issue https://github.com/laxnpander/OpenREALM/issues/38

## Reason

Crashes are bad...

## Method / Design

Changes included:

- Add a mutex around the keyframe_links to prevent updates while inside an iterator that could segfault/crash
- Detect when OpenVSLAM issued an internal reset and reset the KeyframeUpdater as well
- Fix the iterator never incrementing in the KeyframeUpdater that was never updating

## Testing
Compiled and run on:
Ubuntu 20.04 - Desktop

## Other Notes
