### PR TITLE
Add logging flag and only create folders if we plan to write data

### DIFF
--- a/modules/realm_stages/include/realm_stages/densification.h
+++ b/modules/realm_stages/include/realm_stages/densification.h
@@ -42,6 +42,11 @@ class Densification : public StageBase
         bool save_sparse;
         bool save_thumb;
         bool save_normals;
+
+      bool save_required()
+      {
+        return save_bilat || save_dense || save_guided || save_imgs || save_sparse || save_thumb || save_normals;
+      }
     };
 
   public:

--- a/modules/realm_stages/include/realm_stages/mosaicing.h
+++ b/modules/realm_stages/include/realm_stages/mosaicing.h
@@ -50,6 +50,48 @@ class Mosaicing : public StageBase
         bool save_num_obs_one;
         bool save_num_obs_all;
         bool save_dense_ply;
+
+        bool save_required()
+        {
+          return split_gtiff_channels || save_ortho_rgb_one || save_ortho_rgb_all ||
+                 save_ortho_gtiff_one || save_ortho_gtiff_all || save_elevation_one || save_elevation_all ||
+                 save_elevation_var_one || save_elevation_var_all ||
+                 save_elevation_obs_angle_one || save_elevation_obs_angle_all ||
+                 save_elevation_mesh_one || save_num_obs_one || save_num_obs_all || save_dense_ply;
+        }
+
+        bool save_elevation()
+        {
+          return save_elevation_one || save_elevation_all ||
+                 save_elevation_obs_angle_one || save_elevation_obs_angle_all ||
+                 save_elevation_var_one || save_elevation_var_all ||
+                 save_elevation_mesh_one;
+        }
+
+        bool save_ortho()
+        {
+          return save_ortho_rgb_one || save_ortho_rgb_all || save_ortho_gtiff_one || save_ortho_gtiff_all;
+        }
+
+        bool save_nobs()
+        {
+          return save_num_obs_one || save_num_obs_all;
+        }
+
+        bool save_obs_angle()
+        {
+          return save_elevation_obs_angle_one || save_elevation_obs_angle_all;
+        }
+
+        bool save_variance()
+        {
+          return save_elevation_var_one || save_elevation_var_all;
+        }
+
+        bool save_elevation_map()
+        {
+          return save_elevation_one || save_elevation_all;
+        }
     };
 
   public:

--- a/modules/realm_stages/include/realm_stages/ortho_rectification.h
+++ b/modules/realm_stages/include/realm_stages/ortho_rectification.h
@@ -30,6 +30,12 @@ class OrthoRectification : public StageBase
         bool save_ortho_gtiff;
         bool save_elevation;
         bool save_elevation_angle;
+
+      bool save_required()
+      {
+        return save_ortho_rgb || save_ortho_gtiff ||
+               save_elevation || save_elevation_angle;
+      }
     };
 
   public:

--- a/modules/realm_stages/include/realm_stages/pose_estimation.h
+++ b/modules/realm_stages/include/realm_stages/pose_estimation.h
@@ -54,6 +54,17 @@ class PoseEstimation : public StageBase
         bool save_frames;
         bool save_keyframes;
         bool save_keyframes_full;
+
+        bool save_required()
+        {
+          return save_trajectory_gnss || save_trajectory_visual ||
+                 save_frames || save_keyframes || save_keyframes_full;
+        }
+
+        bool save_trajectory()
+        {
+          return save_trajectory_gnss || save_trajectory_visual;
+        }
     };
 
   public:

--- a/modules/realm_stages/include/realm_stages/stage_base.h
+++ b/modules/realm_stages/include/realm_stages/stage_base.h
@@ -66,8 +66,11 @@ class StageBase : public WorkerThreadBase
      * @brief Basic constructor for stage class
      * @param name Name of the stage, should be set by derived stage
      * @param path Path to the input/output folder for stage informations
+     * @param rate The rate to run the stage at
+     * @param queue_size The maximum depth of the main queue for the stage
+     * @param log_to_file True to log message to the stage directory, false to log to stdout/stderr only
      */
-    StageBase(const std::string &name, const std::string &path, double rate, int queue_size);
+    StageBase(const std::string &name, const std::string &path, double rate, int queue_size, bool log_to_file);
 
     /*!
      * @brief Communication thread of the stage will receive data from the previous stage and feed it into the
@@ -203,6 +206,11 @@ class StageBase : public WorkerThreadBase
      * @brief Path of the stage package. Is used for output writing.
      */
     std::string m_stage_path;
+
+    /*!
+     * @brief flag to indicate if we should write to a separate log file or not
+     */
+    bool m_log_to_file;
 
     /*!
      * @brief This function consists of a result frame, a defined topic as description for the data (for example:

--- a/modules/realm_stages/include/realm_stages/stage_settings.h
+++ b/modules/realm_stages/include/realm_stages/stage_settings.h
@@ -19,6 +19,7 @@ class StageSettings : public SettingsBase
       add("type", Parameter_t<std::string>{"", "Stage type, e.g. pose_estimation, densification, ..."});
       add("queue_size", Parameter_t<int>{5, "Size of the measurement input queue, implemented as ringbuffer"});
       add("path_output", Parameter_t<std::string>{"", "Path to output folder."});
+      add("log_to_file", Parameter_t<int>{1, "Write log to stage directory"});
     }
 };
 

--- a/modules/realm_stages/include/realm_stages/surface_generation.h
+++ b/modules/realm_stages/include/realm_stages/surface_generation.h
@@ -25,6 +25,11 @@ class SurfaceGeneration : public StageBase
     {
         bool save_elevation;
         bool save_normals;
+
+      bool save_required()
+      {
+        return save_elevation || save_normals;
+      }
     };
 
   public:

--- a/modules/realm_stages/src/densification.cpp
+++ b/modules/realm_stages/src/densification.cpp
@@ -338,24 +338,30 @@ void Densification::reset()
 
 void Densification::initStageCallback()
 {
+  // If we aren't saving any information, skip directory creation
+  if (!(m_log_to_file || m_settings_save.save_required()))
+  {
+    return;
+  }
+
   // Stage directory first
   if (!io::dirExists(m_stage_path))
     io::createDir(m_stage_path);
 
   // Then sub directories
-  if (!io::dirExists(m_stage_path + "/sparse"))
+  if (!io::dirExists(m_stage_path + "/sparse") && m_settings_save.save_sparse)
     io::createDir(m_stage_path + "/sparse");
-  if (!io::dirExists(m_stage_path + "/dense"))
+  if (!io::dirExists(m_stage_path + "/dense") && m_settings_save.save_dense)
     io::createDir(m_stage_path + "/dense");
-  if (!io::dirExists(m_stage_path + "/bilat"))
+  if (!io::dirExists(m_stage_path + "/bilat") && m_settings_save.save_bilat)
     io::createDir(m_stage_path + "/bilat");
-  if (!io::dirExists(m_stage_path + "/guided"))
+  if (!io::dirExists(m_stage_path + "/guided") && m_settings_save.save_guided)
     io::createDir(m_stage_path + "/guided");
-  if (!io::dirExists(m_stage_path + "/normals"))
+  if (!io::dirExists(m_stage_path + "/normals") && m_settings_save.save_normals)
     io::createDir(m_stage_path + "/normals");
-  if (!io::dirExists(m_stage_path + "/imgs"))
+  if (!io::dirExists(m_stage_path + "/imgs") && m_settings_save.save_imgs)
     io::createDir(m_stage_path + "/imgs");
-  if (!io::dirExists(m_stage_path + "/thumb"))
+  if (!io::dirExists(m_stage_path + "/thumb") && m_settings_save.save_thumb)
     io::createDir(m_stage_path + "/thumb");
 }
 

--- a/modules/realm_stages/src/densification.cpp
+++ b/modules/realm_stages/src/densification.cpp
@@ -8,7 +8,7 @@ using namespace stages;
 Densification::Densification(const StageSettings::Ptr &stage_set,
                              const DensifierSettings::Ptr &densifier_set,
                              double rate)
-: StageBase("densification", (*stage_set)["path_output"].toString(), rate, (*stage_set)["queue_size"].toInt()),
+: StageBase("densification", (*stage_set)["path_output"].toString(), rate, (*stage_set)["queue_size"].toInt(), bool((*stage_set)["log_to_file"].toInt())),
   m_use_filter_bilat((*stage_set)["use_filter_bilat"].toInt() > 0),
   m_use_filter_guided((*stage_set)["use_filter_guided"].toInt() > 0),
   m_depth_min_current(0.0),

--- a/modules/realm_stages/src/mosaicing.cpp
+++ b/modules/realm_stages/src/mosaicing.cpp
@@ -289,30 +289,35 @@ Frame::Ptr Mosaicing::getNewFrame()
 
 void Mosaicing::initStageCallback()
 {
+  // If we aren't saving any information, skip directory creation
+  if (!(m_log_to_file || m_settings_save.save_required()))
+  {
+    return;
+  }
+
   // Stage directory first
   if (!io::dirExists(m_stage_path))
     io::createDir(m_stage_path);
 
   // Then sub directories
-  if (!io::dirExists(m_stage_path + "/elevation"))
+  if (!io::dirExists(m_stage_path + "/elevation") && m_settings_save.save_elevation())
     io::createDir(m_stage_path + "/elevation");
-  if (!io::dirExists(m_stage_path + "/elevation/color_map"))
+  if (!io::dirExists(m_stage_path + "/elevation/color_map") && m_settings_save.save_elevation_map())
     io::createDir(m_stage_path + "/elevation/color_map");
-  if (!io::dirExists(m_stage_path + "/elevation/ply"))
+  if (!io::dirExists(m_stage_path + "/elevation/ply") && m_settings_save.save_dense_ply)
     io::createDir(m_stage_path + "/elevation/ply");
-  if (!io::dirExists(m_stage_path + "/elevation/pcd"))
-    io::createDir(m_stage_path + "/elevation/pcd");
-  if (!io::dirExists(m_stage_path + "/elevation/mesh"))
+  if (!io::dirExists(m_stage_path + "/elevation/mesh") && m_settings_save.save_elevation_mesh_one)
     io::createDir(m_stage_path + "/elevation/mesh");
-  if (!io::dirExists(m_stage_path + "/elevation/gtiff"))
+  if (!io::dirExists(m_stage_path + "/elevation/gtiff") && m_settings_save.save_elevation_map())
     io::createDir(m_stage_path + "/elevation/gtiff");
-  if (!io::dirExists(m_stage_path + "/obs_angle"))
+
+  if (!io::dirExists(m_stage_path + "/obs_angle") && m_settings_save.save_obs_angle())
     io::createDir(m_stage_path + "/obs_angle");
-  if (!io::dirExists(m_stage_path + "/variance"))
+  if (!io::dirExists(m_stage_path + "/variance") && m_settings_save.save_variance())
     io::createDir(m_stage_path + "/variance");
-  if (!io::dirExists(m_stage_path + "/ortho"))
+  if (!io::dirExists(m_stage_path + "/ortho") && m_settings_save.save_ortho())
     io::createDir(m_stage_path + "/ortho");
-  if (!io::dirExists(m_stage_path + "/nobs"))
+  if (!io::dirExists(m_stage_path + "/nobs") && m_settings_save.save_nobs())
     io::createDir(m_stage_path + "/nobs");
 }
 

--- a/modules/realm_stages/src/mosaicing.cpp
+++ b/modules/realm_stages/src/mosaicing.cpp
@@ -10,7 +10,7 @@ using namespace realm;
 using namespace stages;
 
 Mosaicing::Mosaicing(const StageSettings::Ptr &stage_set, double rate)
-    : StageBase("mosaicing", (*stage_set)["path_output"].toString(), rate, (*stage_set)["queue_size"].toInt()),
+    : StageBase("mosaicing", (*stage_set)["path_output"].toString(), rate, (*stage_set)["queue_size"].toInt(), bool((*stage_set)["log_to_file"].toInt())),
       m_utm_reference(nullptr),
       m_global_map(nullptr),
       //m_mesher(nullptr),

--- a/modules/realm_stages/src/ortho_rectification.cpp
+++ b/modules/realm_stages/src/ortho_rectification.cpp
@@ -8,7 +8,7 @@ using namespace realm;
 using namespace stages;
 
 OrthoRectification::OrthoRectification(const StageSettings::Ptr &stage_set, double rate)
-    : StageBase("ortho_rectification", (*stage_set)["path_output"].toString(), rate, (*stage_set)["queue_size"].toInt()),
+    : StageBase("ortho_rectification", (*stage_set)["path_output"].toString(), rate, (*stage_set)["queue_size"].toInt(), bool((*stage_set)["log_to_file"].toInt())),
       m_do_publish_pointcloud((*stage_set)["publish_pointcloud"].toInt() > 0),
       m_GSD((*stage_set)["GSD"].toDouble()),
       m_settings_save({(*stage_set)["save_ortho_rgb"].toInt() > 0,

--- a/modules/realm_stages/src/ortho_rectification.cpp
+++ b/modules/realm_stages/src/ortho_rectification.cpp
@@ -168,18 +168,24 @@ Frame::Ptr OrthoRectification::getNewFrame()
 
 void OrthoRectification::initStageCallback()
 {
+  // If we aren't saving any information, skip directory creation
+  if (!(m_log_to_file || m_settings_save.save_required()))
+  {
+    return;
+  }
+
   // Stage directory first
   if (!io::dirExists(m_stage_path))
     io::createDir(m_stage_path);
 
   // Then sub directories
-  if (!io::dirExists(m_stage_path + "/elevation"))
+  if (!io::dirExists(m_stage_path + "/elevation") && m_settings_save.save_elevation)
     io::createDir(m_stage_path + "/elevation");
-  if (!io::dirExists(m_stage_path + "/angle"))
+  if (!io::dirExists(m_stage_path + "/angle") && m_settings_save.save_elevation_angle)
     io::createDir(m_stage_path + "/angle");
-  if (!io::dirExists(m_stage_path + "/gtiff"))
+  if (!io::dirExists(m_stage_path + "/gtiff") && m_settings_save.save_ortho_gtiff)
     io::createDir(m_stage_path + "/gtiff");
-  if (!io::dirExists(m_stage_path + "/ortho"))
+  if (!io::dirExists(m_stage_path + "/ortho") && m_settings_save.save_ortho_rgb)
     io::createDir(m_stage_path + "/ortho");
 }
 

--- a/modules/realm_stages/src/pose_estimation.cpp
+++ b/modules/realm_stages/src/pose_estimation.cpp
@@ -12,7 +12,7 @@ PoseEstimation::PoseEstimation(const StageSettings::Ptr &stage_set,
                                const CameraSettings::Ptr &cam_set,
                                const ImuSettings::Ptr &imu_set,
                                double rate)
-    : StageBase("pose_estimation", (*stage_set)["path_output"].toString(), rate, (*stage_set)["queue_size"].toInt()),
+    : StageBase("pose_estimation", (*stage_set)["path_output"].toString(), rate, (*stage_set)["queue_size"].toInt(), bool((*stage_set)["log_to_file"].toInt())),
       m_is_georef_initialized(false),
       m_use_vslam((*stage_set)["use_vslam"].toInt() > 0),
       m_use_imu((*stage_set)["use_imu"].toInt() > 0),

--- a/modules/realm_stages/src/pose_estimation.cpp
+++ b/modules/realm_stages/src/pose_estimation.cpp
@@ -325,21 +325,30 @@ bool PoseEstimation::changeParam(const std::string& name, const std::string &val
 
 void PoseEstimation::initStageCallback()
 {
+  // The publisher has to decide on it's own to create folders
+  // So inform it, even if we don't log ourselves
+  m_stage_publisher->setOutputPath(m_stage_path);
+
+  // If we aren't saving any information, skip directory creation
+  if (!(m_log_to_file || m_settings_save.save_required()))
+  {
+    return;
+  }
+
   // Stage directory first
   if (!io::dirExists(m_stage_path))
     io::createDir(m_stage_path);
 
   // Then sub directories
-  if (!io::dirExists(m_stage_path + "/trajectory"))
+  if (!io::dirExists(m_stage_path + "/trajectory") && m_settings_save.save_trajectory())
     io::createDir(m_stage_path + "/trajectory");
-  if (!io::dirExists(m_stage_path + "/keyframes"))
+  if (!io::dirExists(m_stage_path + "/keyframes") && m_settings_save.save_keyframes)
     io::createDir(m_stage_path + "/keyframes");
-  if (!io::dirExists(m_stage_path + "/keyframes_full"))
+  if (!io::dirExists(m_stage_path + "/keyframes_full") && m_settings_save.save_keyframes_full)
     io::createDir(m_stage_path + "/keyframes_full");
-  if (!io::dirExists(m_stage_path + "/frames"))
+  if (!io::dirExists(m_stage_path + "/frames") && m_settings_save.save_frames)
     io::createDir(m_stage_path + "/frames");
 
-  m_stage_publisher->setOutputPath(m_stage_path);
 }
 
 void PoseEstimation::printSettingsToLog()
@@ -536,7 +545,10 @@ void PoseEstimationIO::setOutputPath(const std::string &path)
 
 void PoseEstimationIO::initLog(const std::string &filepath)
 {
-  loguru::add_file((filepath + "/publisher.log").c_str(), loguru::Append, loguru::Verbosity_MAX);
+  // Only log to file if the parent stage is doing so
+  if (m_stage_handle->m_log_to_file) {
+    loguru::add_file((filepath + "/publisher.log").c_str(), loguru::Append, loguru::Verbosity_MAX);
+  }
 
   LOG_F(INFO, "Successfully initialized %s publisher!", m_stage_handle->m_stage_name.c_str());
 }

--- a/modules/realm_stages/src/stage_base.cpp
+++ b/modules/realm_stages/src/stage_base.cpp
@@ -6,11 +6,12 @@
 
 using namespace realm;
 
-StageBase::StageBase(const std::string &name, const std::string &path, double rate, int queue_size)
+StageBase::StageBase(const std::string &name, const std::string &path, double rate, int queue_size, bool log_to_file)
 : WorkerThreadBase("Stage [" + name + "]", static_cast<int64_t>(1/rate*1000.0), true),
   m_stage_name(name),
   m_stage_path(path),
   m_queue_size(queue_size),
+  m_log_to_file(log_to_file),
   m_is_output_dir_initialized(false),
   m_t_statistics_period(10),
   m_counter_frames_in(0),
@@ -32,8 +33,11 @@ void StageBase::initStagePath(const std::string &abs_path)
   initStageCallback();
   m_is_output_dir_initialized = true;
 
-  // Init logging
-  loguru::add_file((m_stage_path + "/stage.log").c_str(), loguru::Append, loguru::Verbosity_MAX);
+  // Init logging if enabled
+  if (m_log_to_file)
+  {
+    loguru::add_file((m_stage_path + "/stage.log").c_str(), loguru::Append, loguru::Verbosity_MAX);
+  }
 
   LOG_F(INFO, "Successfully initialized!");
   LOG_F(INFO, "Stage path set to: %s", m_stage_path.c_str());

--- a/modules/realm_stages/src/surface_generation.cpp
+++ b/modules/realm_stages/src/surface_generation.cpp
@@ -130,14 +130,20 @@ void SurfaceGeneration::saveIter(const CvGridMap &surface, uint32_t id)
 
 void SurfaceGeneration::initStageCallback()
 {
+  // If we aren't saving any information, skip directory creation
+  if (!(m_log_to_file || m_settings_save.save_required()))
+  {
+    return;
+  }
+
   // Stage directory first
   if (!io::dirExists(m_stage_path))
     io::createDir(m_stage_path);
 
   // Then sub directories
-  if (!io::dirExists(m_stage_path + "/elevation"))
+  if (!io::dirExists(m_stage_path + "/elevation") && m_settings_save.save_elevation)
     io::createDir(m_stage_path + "/elevation");
-  if (!io::dirExists(m_stage_path + "/normals"))
+  if (!io::dirExists(m_stage_path + "/normals") && m_settings_save.save_normals)
     io::createDir(m_stage_path + "/normals");
 }
 

--- a/modules/realm_stages/src/surface_generation.cpp
+++ b/modules/realm_stages/src/surface_generation.cpp
@@ -9,7 +9,7 @@ using namespace stages;
 using namespace realm::ortho;
 
 SurfaceGeneration::SurfaceGeneration(const StageSettings::Ptr &settings, double rate)
-: StageBase("surface_generation", (*settings)["path_output"].toString(), rate, (*settings)["queue_size"].toInt()),
+: StageBase("surface_generation", (*settings)["path_output"].toString(), rate, (*settings)["queue_size"].toInt(), bool((*settings)["log_to_file"].toInt())),
   m_try_use_elevation((*settings)["try_use_elevation"].toInt() > 0),
   m_knn_max_iter((*settings)["knn_max_iter"].toInt()),
   m_is_projection_plane_offset_computed(false),

--- a/modules/realm_stages/src/tileing.cpp
+++ b/modules/realm_stages/src/tileing.cpp
@@ -26,7 +26,7 @@ using namespace realm;
 using namespace stages;
 
 Tileing::Tileing(const StageSettings::Ptr &stage_set, double rate)
-    : StageBase("tileing", (*stage_set)["path_output"].toString(), rate, (*stage_set)["queue_size"].toInt()),
+    : StageBase("tileing", (*stage_set)["path_output"].toString(), rate, (*stage_set)["queue_size"].toInt(), bool((*stage_set)["log_to_file"].toInt())),
       m_utm_reference(nullptr),
       m_map_tiler(nullptr),
       m_tile_cache(nullptr),


### PR DESCRIPTION
## Description

This is intended to clean up the logging system for use as a component in other systems.  This consists of allows the user to enable/disable individual stage log files as well as only creating log folders if the particular logging option is enabled.

## Reason

Currently, each stage was configured to log to it's own log file using loguru.  While this works when they are running in separate processes, it results in duplicate log files when they are run in separate threads within the same process.  Allowing them to be disabled individually allows the user to decide if they want each stage to log, or if they want to create their own loguru sink for the whole application.

The system would also create a number of folders that were empty when logging options weren't all enabled.  This would make it more difficult to tell which logging options were enable and disabled for a give run, since you would have to search through each folder manually.  This was cleaned up by not creating folders when the logging options for that folder weren't enabled.

## Method / Design

Changes included:

- Add a base stage setting of *log_to_file* that defaults to on.  This controls whether the individual stage log is written for this stage.
- Check SaveSettings flags before creating folders to avoid creating empty log folders
- Add functions to SaveSettings to group common settings / options into clearer calls for folder creation.

## Testing
Compiled and run on:
Ubuntu 20.04 - Desktop

## Other Notes
