### PR TITLE
Bugfix :: OpenVSlam Crash if close() called twice

### DIFF
--- a/modules/realm_vslam/realm_vslam_base/src/open_vslam.cpp
+++ b/modules/realm_vslam/realm_vslam_base/src/open_vslam.cpp
@@ -145,8 +145,16 @@ VisualSlamIF::State OpenVslam::track(Frame::Ptr &frame, const cv::Mat &T_c2w_ini
 
 void OpenVslam::close()
 {
-  m_vslam->request_terminate();
-  m_vslam->shutdown();
+  // In the current OpenVSLAM build, we don't have a way to know we shut
+  // down other than seeing if we requested a terminate previously.  The internal flag isn't exposed.
+  // So, we assume if we've requested termination, that we have also shut down.
+  // This prevents a crash that could occur if close() was accidentally called twice.
+  if (!m_vslam->terminate_is_requested())
+  {
+    m_vslam->request_terminate();
+    m_vslam->shutdown();
+  }
+
   m_keyframe_updater->requestFinish();
   m_keyframe_updater->join();
 }


### PR DESCRIPTION
## Description

Fixes an issue if close() is called twice on the OpenVSLAM wrapper.  While this shouldn't occur if the library is used correctly, it matches the hardening done in the rest of the system against crashes.

## Reason

Internally, OpenVSLAM ends up called join() on a thread when it isn't in a joinable state.  This throws a standard exception that isn't caught and can crash out the program.  

## Method / Design

OpenVSLAM itself doesn't expose whether a shutdown has already occurred, so as a workaround we check if we have already tried to terminate the main system.  If we have, we do not call shutdown a second time.  This is a bit of a rough workaround, but I don't want to put too much more time into modifying OpenVSLAM as we will likely be moving away from it.

## Testing
Compiled and run on:
Ubuntu 20.04 - Desktop

## Other Notes
