### PR TITLE
Create flag to enable frame by frame planar surfaces

### DIFF
--- a/modules/realm_stages/include/realm_stages/stage_settings.h
+++ b/modules/realm_stages/include/realm_stages/stage_settings.h
@@ -74,6 +74,7 @@ class SurfaceGenerationSettings : public StageSettings
     SurfaceGenerationSettings()
     {
       add("try_use_elevation", Parameter_t<int>{0, "Flag for trying to use surface points for elevation map generation"});
+      add("compute_all_frames", Parameter_t<int>{0, "When in PLANAR mode, estimate the elevation of every frame using sparse data rather than locking on the first"});
       add("knn_max_iter", Parameter_t<int>{5, "Maximum number of iterations for each cell to find the closest 3D point in the dense cloud"});
       add("mode_surface_normals", Parameter_t<int>{0, "0 - None, 1 - Random neighbours, 2 - Furthest neighbours, 3 - Best-fit"});
       add("save_valid", Parameter_t<int>{0, "Save valid elevation grid element mask"});

--- a/modules/realm_stages/include/realm_stages/surface_generation.h
+++ b/modules/realm_stages/include/realm_stages/surface_generation.h
@@ -41,6 +41,7 @@ class SurfaceGeneration : public StageBase
 
     std::mutex m_mutex_params;
     bool m_try_use_elevation;
+    bool m_compute_all_frames;
 
     int m_knn_max_iter;
 

--- a/modules/realm_stages/src/pose_estimation.cpp
+++ b/modules/realm_stages/src/pose_estimation.cpp
@@ -187,18 +187,23 @@ bool PoseEstimation::process()
         if (!is_scale_consistent)
         {
           LOG_F(WARNING, "Detected scale divergence.");
-          frame->setPoseAccurate(false);
-          frame->setKeyframe(false);
 
-          if (m_do_auto_reset)
-          {
-            LOG_F(WARNING, "Resetting.");
-            m_reset_requested = true;
-            reset();
-          }
+          // For now, just warn that our scale may be off until we resolve the issues discussed here:
+          // https://github.com/laxnpander/OpenREALM/pull/59
+
+          // frame->setPoseAccurate(false);
+          // frame->setKeyframe(false);
+          //
+          // if (m_do_auto_reset)
+          // {
+          //   LOG_F(WARNING, "Resetting.");
+          //   m_reset_requested = true;
+          // reset();
+          // }
         }
 
-        if (is_scale_consistent && m_do_update_georef && !m_georeferencer->isBuisy())
+        // if (is_scale_consistent && m_do_update_georef && !m_georeferencer->isBuisy())
+        if (m_do_update_georef && !m_georeferencer->isBuisy())
         {
           std::thread t(std::bind(&GeospatialReferencerIF::update, m_georeferencer, frame));
           t.detach();

--- a/modules/realm_stages/src/pose_estimation.cpp
+++ b/modules/realm_stages/src/pose_estimation.cpp
@@ -595,11 +595,18 @@ bool PoseEstimationIO::process()
     if (!(m_stage_handle->m_do_suppress_outdated_pose_pub && m_stage_handle->m_buffer_do_publish.size() > 1))
       publishPose(frame);
 
+    // Check what type of frame
+    bool is_gnss_frame = !m_stage_handle->m_use_vslam && m_stage_handle->estimatePercOverlap(frame) < m_stage_handle->m_overlap_max_fallback;
+    bool is_vslam_frame = frame->isKeyframe() && m_stage_handle->estimatePercOverlap(frame) < m_stage_handle->m_overlap_max;
+    bool is_vslam_fallback_frame = m_stage_handle->m_use_fallback && !frame->hasAccuratePose() && m_stage_handle->estimatePercOverlap(frame) < m_stage_handle->m_overlap_max_fallback;
+
     // Keyframes to be published (big data packages -> publish only if needed)
-    if ((m_stage_handle->m_use_fallback && !frame->hasAccuratePose() && m_stage_handle->estimatePercOverlap(frame) < m_stage_handle->m_overlap_max_fallback)
-         ||(!m_stage_handle->m_use_vslam && m_stage_handle->estimatePercOverlap(frame) < m_stage_handle->m_overlap_max_fallback)
-         || (frame->isKeyframe() && m_stage_handle->estimatePercOverlap(frame) < m_stage_handle->m_overlap_max))
+    if (is_gnss_frame || is_vslam_frame || is_vslam_fallback_frame)
     {
+      if (is_vslam_fallback_frame)
+      {
+        LOG_F(INFO, "VSLAM tracking lost, using GNSS fallback for frame %d!", frame->getFrameId());
+      }
       m_stage_handle->updatePreviousRoi(frame);
       if (m_do_delay_keyframes)
         scheduleFrame(frame);

--- a/modules/realm_stages/src/stage_base.cpp
+++ b/modules/realm_stages/src/stage_base.cpp
@@ -72,7 +72,7 @@ void StageBase::registerDepthMapTransport(const std::function<void(const cv::Mat
   m_transport_depth_map = func;
 }
 
-void StageBase::registerPointCloudTransport(const std::function<void(const cv::Mat&, const std::string&)> &func)
+void StageBase::registerPointCloudTransport(const std::function<void(const PointCloud::Ptr &, const std::string&)> &func)
 {
   m_transport_pointcloud = func;
 }

--- a/modules/realm_stages/src/surface_generation.cpp
+++ b/modules/realm_stages/src/surface_generation.cpp
@@ -11,6 +11,7 @@ using namespace realm::ortho;
 SurfaceGeneration::SurfaceGeneration(const StageSettings::Ptr &settings, double rate)
 : StageBase("surface_generation", (*settings)["path_output"].toString(), rate, (*settings)["queue_size"].toInt(), bool((*settings)["log_to_file"].toInt())),
   m_try_use_elevation((*settings)["try_use_elevation"].toInt() > 0),
+  m_compute_all_frames((*settings)["compute_all_frames"].toInt() > 0),
   m_knn_max_iter((*settings)["knn_max_iter"].toInt()),
   m_is_projection_plane_offset_computed(false),
   m_projection_plane_offset(0.0),
@@ -101,6 +102,12 @@ bool SurfaceGeneration::changeParam(const std::string& name, const std::string &
     m_try_use_elevation = (val == "true" || val == "1");
     return true;
   }
+  else if (name == "compute_all_frames")
+  {
+    m_compute_all_frames = (val == "true" || val == "1");
+    return true;
+  }
+
   return false;
 }
 
@@ -151,6 +158,7 @@ void SurfaceGeneration::printSettingsToLog()
 {
   LOG_F(INFO, "### Stage process settings ###");
   LOG_F(INFO, "- try_use_elevation: %i", m_try_use_elevation);
+  LOG_F(INFO, "- compute_all_frames: %i", m_compute_all_frames);
   LOG_F(INFO, "- mode_surface_normals: %i", static_cast<int>(m_mode_surface_normals));
 
   LOG_F(INFO, "### Stage save settings ###");
@@ -214,7 +222,7 @@ double SurfaceGeneration::computeProjectionPlaneOffset(const Frame::Ptr &frame)
 
 DigitalSurfaceModel::Ptr SurfaceGeneration::createPlanarSurface(const Frame::Ptr &frame)
 {
-  if (!m_is_projection_plane_offset_computed)
+  if (!m_is_projection_plane_offset_computed || m_compute_all_frames)
   {
     m_projection_plane_offset = computeProjectionPlaneOffset(frame);
   }

--- a/modules/realm_stages/src/surface_generation.cpp
+++ b/modules/realm_stages/src/surface_generation.cpp
@@ -200,6 +200,9 @@ double SurfaceGeneration::computeProjectionPlaneOffset(const Frame::Ptr &frame)
     offset = z_coord[(z_coord.size() - 1) / 2];
 
     LOG_F(INFO, "Sparse cloud was utilized to compute an initial projection plane at elevation = %4.2f.", offset);
+
+    // Only consider the plane offset computed if we had a sparse cloud to work with.
+    m_is_projection_plane_offset_computed = true;
   }
   else
   {
@@ -214,7 +217,6 @@ DigitalSurfaceModel::Ptr SurfaceGeneration::createPlanarSurface(const Frame::Ptr
   if (!m_is_projection_plane_offset_computed)
   {
     m_projection_plane_offset = computeProjectionPlaneOffset(frame);
-    m_is_projection_plane_offset_computed = true;
   }
 
   // Create planar surface in world frame


### PR DESCRIPTION
## Description

This will add the capability to allow for PLANAR surfaces to be constructed on a frame by frame basis, rather than locking in on the first good offset estimate. Additional feedback as to when fallback mode is used for a projection has also been added.

Further discussion and samples can be found at the end of the issue discussion here: https://github.com/laxnpander/OpenREALM/issues/57


## Reason

Currently, the `surface_generation.cpp` node will lock on to the first good ground estimate when running in PLANAR mode.  This was originally done to improve stitching quality in cases where the surface planar adjustments were creating worse results.  There appear to be many cases where allowing a frame by frame adjustment of the planar surface does result in a better final stitch, so an option to selectively enable/disable it will allow either to be used.

## Method / Design

* A new parameter was added to 'surface_generation.yaml` which allows enabling of frame by frame adjustments in 2.5D planar mode.
`compute_all_frames` - When in PLANAR mode, estimate the elevation of every frame using sparse data rather than locking on the first - Default: off

* For better feedback in the logs, a log message is now emitted if fallback mode was used.  This should make it easier to tell when accurate vs inaccurate poses were used to project a frame.

* A minor bug in fallback mode that resulted in the first fallback frame setting the surface generation offset for the entire flight (rather than waiting for VSLAM corrected values) was also corrected.

## Testing
Compiled and run on:
* Ubuntu 20.04 - Desktop
* Custom OpenREALM wrapper (non-ROS)

## Other Notes
