### PR TITLE
Reset SLAM if tracking is lost during georeferencing initialization

### DIFF
--- a/modules/realm_core/src/frame.cpp
+++ b/modules/realm_core/src/frame.cpp
@@ -350,6 +350,10 @@ void Frame::setKeyframe(bool flag)
 void Frame::setPoseAccurate(bool flag)
 {
   std::lock_guard<std::mutex> lock(m_mutex_flags);
+  // If we are clearing the flag, clear the georeferenced pose data as well
+  if (!flag) {
+    m_camera_model->setPose(getDefaultPose());
+  }
   m_has_accurate_pose = flag;
 }
 

--- a/modules/realm_stages/include/realm_stages/pose_estimation.h
+++ b/modules/realm_stages/include/realm_stages/pose_estimation.h
@@ -98,6 +98,10 @@ class PoseEstimation : public StageBase
     // Flag to disable fallback solution based on lat/lon/alt/heading completely
     bool m_use_fallback;
 
+    // The maximum number of lost frames when initializing before attempting a reset
+    int m_init_lost_frames_reset_count;
+    int m_init_lost_frames;
+
     // Flag to disable using an initial guess of the camera pose to make tracking more stable in the visual SLAM
     bool m_use_initial_guess;
 

--- a/modules/realm_stages/include/realm_stages/stage_settings.h
+++ b/modules/realm_stages/include/realm_stages/stage_settings.h
@@ -38,6 +38,7 @@ class PoseEstimationSettings : public StageSettings
                                                                            "This ensures higher pose and map point quality, as the frames are refined with consecutive frames."});
       add("suppress_outdated_pose_pub", Parameter_t<int>{0, "Flag to suppress publish of outdated poses after georeference computation."});
       add("th_error_georef", Parameter_t<double>{1.0, "Threshold of error for georeference until initialization is performed."});
+      add("init_lost_frames_reset_count", Parameter_t<int>{15, "The number of lost frames allowed during georeferencing before a VSLAM reset is issued."});
       add("min_nrof_frames_georef", Parameter_t<int>{5, "Minimum number of unique frames required before georeference is initialized."});
       add("overlap_max", Parameter_t<double>{0.0, "Maximum overlap for all publishes, even keyframes"});
       add("overlap_max_fallback", Parameter_t<double>{0.0, "Maximum overlap for fallback publishes, e.g. GNSS only imgs"});

--- a/modules/realm_stages/src/pose_estimation.cpp
+++ b/modules/realm_stages/src/pose_estimation.cpp
@@ -19,6 +19,8 @@ PoseEstimation::PoseEstimation(const StageSettings::Ptr &stage_set,
       m_set_all_frames_keyframes((*stage_set)["set_all_frames_keyframes"].toInt() > 0),
       m_strategy_fallback(PoseEstimation::FallbackStrategy((*stage_set)["fallback_strategy"].toInt())),
       m_use_fallback(false),
+      m_init_lost_frames_reset_count((*stage_set)["init_lost_frames_reset_count"].toInt()),
+      m_init_lost_frames(0),
       m_use_initial_guess((*stage_set)["use_initial_guess"].toInt() > 0),
       m_do_update_georef((*stage_set)["update_georef"].toInt() > 0),
       m_do_delay_keyframes((*stage_set)["do_delay_keyframes"].toInt() > 0),
@@ -273,6 +275,20 @@ void PoseEstimation::track(Frame::Ptr &frame)
   switch (state)
   {
     case VisualSlamIF::State::LOST:
+
+      // If we haven't yet initialized, make sure we haven't completely lost tracking.  If we have, force a reset
+      // to hopefully recover.
+      if (!m_is_georef_initialized) {
+        m_init_lost_frames++;
+
+        if (m_init_lost_frames > m_init_lost_frames_reset_count) {
+          LOG_F(WARNING, "Lost tracking while initializing georeferencing, resetting VSLAM to reacquire reference...");
+          std::unique_lock<std::mutex> lock(m_mutex_vslam);
+          m_vslam->reset();
+          m_init_lost_frames = 0;
+        }
+      }
+
       if (estimatePercOverlap(frame) < m_overlap_max_fallback)
         pushToBufferPublish(frame);
       LOG_F(WARNING, "No tracking.");
@@ -323,6 +339,8 @@ void PoseEstimation::reset()
   m_buffer_pose_all.clear();
   m_buffer_no_pose.clear();
   m_buffer_pose_init.clear();
+
+  m_init_lost_frames = 0;
 
   // Reset georeferencing
   if (m_use_vslam)
@@ -384,6 +402,8 @@ void PoseEstimation::printSettingsToLog()
   LOG_F(INFO, "- do_update_georef: %i", m_do_update_georef);
   LOG_F(INFO, "- do_suppress_outdated_pose_pub: %i", m_do_suppress_outdated_pose_pub);
   LOG_F(INFO, "- th_error_georef: %4.2f", m_th_error_georef);
+  LOG_F(INFO, "- min_nrof_frames_georef: %d", m_min_nrof_frames_georef);
+  LOG_F(INFO, "- init_lost_frames_reset_count: %df", m_init_lost_frames_reset_count);
   LOG_F(INFO, "- overlap_max: %4.2f", m_overlap_max);
   LOG_F(INFO, "- overlap_max_fallback: %4.2f", m_overlap_max_fallback);
 


### PR DESCRIPTION
## Description

This introduces a method to reset SLAM tracking in the case that tracking is lost before georeferencing has been initialized.  The exact number of lost frames that trigger this reset can be tuned by a new parameter to avoid false resets.


## Reason

On particularily challenging datasets, there have been cases where tracking was lost before the georeferencer fully initialized.  When this happens, two problems occur.

1) The frames that are in the initialization buffer are stuck and never written out (unless tracking somehow recovers)
2) VSLAM typically doesn't recover (especially in cases where the loss of tracking was due to poor initialization)

By resetting the SLAM module, we can reinitialize both SLAM and the georeferencer to give another attempt at creating a good map.   We don't reset the module if the georeferencer has been initialized, mostly because we want to avoid a reset in cases where we may lose tracking for a while, but regain it during a loop closure event.

## Method / Design

* Added parameter `init_lost_frames_reset_count` to set the number of lost frames that are allowed during georeferencing before a reset is triggered
* Resets are only triggered if georeferencing has not yet been initialized
* The VSLAM reset will trigger code that dumps the init frames to the publish queue to avoid gaps in the map due to failed initialization


## Testing
Compiled and run on:
* Ubuntu 20.04 - Desktop
* Custom OpenREALM wrapper (non-ROS)

## Other Notes

* Also fixes a bug in reset() where frames were being set to inaccurate pose while still containing the VSLAM world-camera matrices.  When they were projected, they would be in visual coordinates, rather than world coordinates.  Resetting the camera model pose fixes this.
* Added display of  `min_nrof_frames_georef` to log