### PR TITLE
Change keyframe updater to use a future

### DIFF
--- a/modules/realm_vslam/realm_vslam_base/include/realm_vslam_base/open_vslam.h
+++ b/modules/realm_vslam/realm_vslam_base/include/realm_vslam_base/open_vslam.h
@@ -13,6 +13,7 @@
 #include <openvslam/data/keyframe.h>
 #include <openvslam/data/landmark.h>
 #include <yaml-cpp/yaml.h>
+#include <future>
 
 namespace realm
 {
@@ -65,6 +66,8 @@ private:
   std::shared_ptr<openvslam::publish::map_publisher> m_map_publisher;
 
   VisualSlamIF::ResetFuncCb m_reset_callback;
+
+  std::future<void> m_future_update_keyframes;
 
   uint32_t extractPointId(openvslam::data::landmark* lm);
 


### PR DESCRIPTION
## Description

Switch keyframe updater from a detached thread to a future.  This will help ensure we do not fall behind, but dropping updates that take too long with an appropriate warning.

## Reason

See https://github.com/laxnpander/OpenREALM/issues/38

## Method / Design

* Futures allow us to check if the previous async thread has completed before starting a new one.


## Testing
Compiled and run on:
* Ubuntu 20.04 - Desktop
* Custom OpenREALM wrapper (non-ROS)

## Other Notes
