### PR TITLE
Crash fixes and memory leaks

### DIFF
--- a/modules/realm_stages/src/surface_generation.cpp
+++ b/modules/realm_stages/src/surface_generation.cpp
@@ -127,12 +127,18 @@ void SurfaceGeneration::publish(const Frame::Ptr &frame)
 void SurfaceGeneration::saveIter(const CvGridMap &surface, uint32_t id)
 {
   // Invalid points are marked with NaN
-  cv::Mat valid = (surface["elevation"] == surface["elevation"]);
+  if (!surface["elevation"].empty()) {
+    cv::Mat valid = (surface["elevation"] == surface["elevation"]);
 
-  if (m_settings_save.save_elevation)
-    io::saveImageColorMap(surface["elevation"], valid, m_stage_path + "/elevation", "elevation", id, io::ColormapType::ELEVATION);
-  if (m_settings_save.save_normals && surface.exists("elevation_normal"))
-    io::saveImageColorMap(surface["elevation_normal"], valid, m_stage_path + "/normals", "normal", id, io::ColormapType::NORMALS);
+    if (m_settings_save.save_elevation)
+      io::saveImageColorMap(surface["elevation"], valid, m_stage_path + "/elevation", "elevation", id,
+                            io::ColormapType::ELEVATION);
+    if (m_settings_save.save_normals && surface.exists("elevation_normal"))
+      io::saveImageColorMap(surface["elevation_normal"], valid, m_stage_path + "/normals", "normal", id,
+                            io::ColormapType::NORMALS);
+  } else {
+    LOG_F(WARNING, "Elevation surface was empty, skipping saveIter()!");
+  }
 }
 
 void SurfaceGeneration::initStageCallback()


### PR DESCRIPTION
## Description

Fixes a race condition crash that can occur in rare instances where elevation isn't present before being accessed.
Clean up GDAL calls that weren't explicitly freed leading to potentially memory leaks.

## Reason

General stability and cleanup.

## Method / Design

* Elevation reset was manually checked by inducing the crash by suppressing elevation updates.  The patch resolved both the induced crash as well as repeated testing in production.
* GDAL memory leaks were located via stack tracing and running `Valigrind Memcheck` on the active code base.  No other major leaks were detected via the tool at this time.


## Testing
Compiled and run on:
* Ubuntu 20.04 - Desktop
* Custom OpenREALM wrapper (non-ROS)

## Other Notes
